### PR TITLE
Region selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sts": "^3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "^3.303.0",
         "bluebird": "^3.7.2",
         "electron": "^23.1.3",
         "home-dir": "^1.0.0",
@@ -325,6 +326,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.292.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.292.0.tgz",
@@ -338,6 +351,18 @@
         "@aws-sdk/credential-provider-web-identity": "3.292.0",
         "@aws-sdk/property-provider": "3.292.0",
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
       },
@@ -359,6 +384,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.292.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.292.0.tgz",
@@ -368,6 +405,18 @@
         "@aws-sdk/property-provider": "3.292.0",
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/token-providers": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
       },
@@ -610,6 +659,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/node-http-handler": {
       "version": "3.292.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.292.0.tgz",
@@ -683,12 +744,23 @@
       }
     },
     "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.292.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
-      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "version": "3.303.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.303.0.tgz",
+      "integrity": "sha512-yI84mnnh3pdQtIOo+oGWofaI0rvfhp3DOavB8KHIkQr+RcjF+fxsqbelRfVb25gx7yEWPNCMB8wM+HhklSEFJg==",
       "dependencies": {
-        "@aws-sdk/types": "3.292.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.303.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/@aws-sdk/types": {
+      "version": "3.303.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.303.0.tgz",
+      "integrity": "sha512-H+Cy8JDTsK87MID6MJbV9ad5xdS9YvaLZSeveC2Zs1WNu2Rp6X9j+mg3EqDSmBKUQVAFRy2b+CSKkH3nnBMedw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -732,6 +804,18 @@
         "@aws-sdk/client-sso-oidc": "3.292.0",
         "@aws-sdk/property-provider": "3.292.0",
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "dependencies": {
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
       },
@@ -8136,6 +8220,17 @@
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-node": {
@@ -8153,6 +8248,17 @@
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-process": {
@@ -8164,6 +8270,17 @@
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-sso": {
@@ -8177,6 +8294,17 @@
         "@aws-sdk/token-providers": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
@@ -8366,6 +8494,17 @@
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/node-http-handler": {
@@ -8423,12 +8562,22 @@
       "integrity": "sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw=="
     },
     "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.292.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
-      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "version": "3.303.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.303.0.tgz",
+      "integrity": "sha512-yI84mnnh3pdQtIOo+oGWofaI0rvfhp3DOavB8KHIkQr+RcjF+fxsqbelRfVb25gx7yEWPNCMB8wM+HhklSEFJg==",
       "requires": {
-        "@aws-sdk/types": "3.292.0",
-        "tslib": "^2.3.1"
+        "@aws-sdk/types": "3.303.0",
+        "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.303.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.303.0.tgz",
+          "integrity": "sha512-H+Cy8JDTsK87MID6MJbV9ad5xdS9YvaLZSeveC2Zs1WNu2Rp6X9j+mg3EqDSmBKUQVAFRy2b+CSKkH3nnBMedw==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/signature-v4": {
@@ -8465,6 +8614,17 @@
         "@aws-sdk/shared-ini-file-loader": "3.292.0",
         "@aws-sdk/types": "3.292.0",
         "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.292.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+          "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+          "requires": {
+            "@aws-sdk/types": "3.292.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/types": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sts": "^3.292.0",
+    "@aws-sdk/shared-ini-file-loader": "^3.303.0",
     "bluebird": "^3.7.2",
     "electron": "^23.1.3",
     "home-dir": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { app } = require('electron');
-const { getArgs, obtainAllCredentials, obtainSaml, listRoles } = require('./lib');
+const { getArgs, obtainAllCredentials, obtainSaml, listRoles, getDefaultRegion } = require('./lib');
 
 /* istanbul ignore next - CLI execution only */
 if (app && app.on) {
@@ -11,7 +11,7 @@ async function main () {
     const args = getArgs();
 
     const startUrl = args.url || process.env.AWS_CREDFUL_URL;
-    const region = args.region || process.env.AWS_CREDFUL_REGION;
+    const region = args.region || await getDefaultRegion() || 'us-east-1';
     if (!startUrl) {
       console.error('No URL specified');
       return app.quit();

--- a/src/lib.js
+++ b/src/lib.js
@@ -32,7 +32,8 @@ function getArgs () {
     .parse());
 }
 
-function getConfig ({ profileName, accessKey, secretKey, sessionToken }) {
+/* Retrieve a profile from AWS' credentials INI file with some credentials added. */
+function getModifiedConfig ({ profileName, accessKey, secretKey, sessionToken }) {
   const awsPath = path.join(homedir(), '.aws');
   try {
     fs.mkdirSync(awsPath);
@@ -60,6 +61,8 @@ function getConfig ({ profileName, accessKey, secretKey, sessionToken }) {
   return { config, credentialsPath };
 }
 
+/* Get the region from the standard env var or config file used by the AWS SDK/CLI, but allow an undefined
+result that must be defaulted elsewhere. */
 async function getDefaultRegion () {
   if (process.env.AWS_REGION) {
     return process.env.AWS_REGION;
@@ -95,7 +98,7 @@ async function obtainAllCredentials (roles, outputs, samlResponse, hours, region
 
 /* Save AWS credentials to a named profile in the ~/.aws/credentials file */
 function saveProfile (profileName, accessKey, secretKey, sessionToken) {
-  const { config, credentialsPath } = getConfig({ profileName, accessKey, secretKey, sessionToken });
+  const { config, credentialsPath } = getModifiedConfig({ profileName, accessKey, secretKey, sessionToken });
   fs.writeFileSync(credentialsPath, ini.stringify(config));
 }
 

--- a/tests/credentials.test.js
+++ b/tests/credentials.test.js
@@ -4,8 +4,6 @@ const sinon = require('sinon');
 const path = require('path');
 const { EOL } = require('os');
 
-// Create a multi-platform expectation for testing
-const expectedConfigPath = path.join('/home', '.aws', 'config');
 const expectedCredentialsPath = path.join('/home', '.aws', 'credentials');
 
 function platformEol (str) {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -13,7 +13,7 @@ test.beforeEach(t => {
     listRoles: sinon.stub(),
     getConfig: sinon.stub(),
     obtainAllCredentials: sinon.stub(),
-    getDefaultRegion: sinon.stub(),
+    getDefaultRegion: sinon.stub()
   };
   t.context.stubs = {
     electron: {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -12,7 +12,8 @@ test.beforeEach(t => {
     obtainSaml: sinon.stub().resolves(''),
     listRoles: sinon.stub(),
     getConfig: sinon.stub(),
-    obtainAllCredentials: sinon.stub()
+    obtainAllCredentials: sinon.stub(),
+    getDefaultRegion: sinon.stub(),
   };
   t.context.stubs = {
     electron: {
@@ -77,4 +78,3 @@ test('outputs all roles', async t => {
     'us-east-1'
   ]);
 });
-


### PR DESCRIPTION
Support a `--region` argument, `AWS_REGION` env var, and default region from config file, falling back to `us-east-1`, for the STS call.

Closes https://github.com/credful/aws-credful/issues/30

FYI @dustingraves I moved your commits here for some updates from the other thread.